### PR TITLE
Testing multiple varnish caches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ stop-containers: ## Stop containers
 	@docker-compose down
 
 .PHONY: tests
-tests: ## Stop containers
+tests: ## Run Tests
 	bin/pytest tests
 
 .PHONY: run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,6 @@ services:
         aliases:
           - plone.localhost
     ports:
-      - "8000:80"
+      - "8000-8001:80"
     depends_on:
       - backend

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # Standard Library
 import json
+import subprocess
 from pathlib import Path
 from time import sleep
 
@@ -15,7 +16,15 @@ API_URL = f"{BASE_URL}/++api++"
 
 BACKEND_URL = "http://plone.localhost:8080/Plone"
 
-VARNISH_URL = "http://plone.localhost:8000"
+VARNISH_PORT = (
+    subprocess.run(
+        ["docker", "compose", "port", "varnish", "80"], capture_output=True, text=True
+    )
+    .stdout.strip()
+    .split(":")[1]
+)
+s
+VARNISH_URL = f"http://plone.localhost:{VARNISH_PORT}"
 
 REPO_DIR = Path(__file__).parent.parent
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,8 +23,10 @@ VARNISH_PORT = (
     .stdout.strip()
     .split(":")[1]
 )
-s
+
 VARNISH_URL = f"http://plone.localhost:{VARNISH_PORT}"
+
+VARNISH_MULTIPLE_URL = ["http://plone.localhost:8000", "http://plone.localhost:8001"]
 
 REPO_DIR = Path(__file__).parent.parent
 
@@ -43,6 +45,19 @@ def varnish_client() -> httpx.Client:
     client = httpx.Client(base_url=VARNISH_URL, headers={"Host": "plone.localhost"})
     yield client
     client.close()
+
+
+@pytest.fixture(scope="session")
+def varnish_multiple_clients() -> list:
+    clients = []
+    for v_url in VARNISH_MULTIPLE_URL:
+        client = httpx.Client(
+            base_url=v_url, headers={"Host": "plone.localhost", "x-varnish-debug": "1"}
+        )
+        clients.append(client)
+    yield clients
+    for client in clients:
+        client.close()
 
 
 @pytest.fixture(scope="session")
@@ -166,5 +181,21 @@ def purge_url(varnish_client: httpx.Client):
             url=url,
         )
         return response.status_code == 200
+
+    return inner
+
+
+@pytest.fixture
+def purge_multiple_varnish_url(varnish_multiple_clients: list):
+    def inner(url: str = "") -> bool:
+        success = True
+        for varnish_client in varnish_multiple_clients:
+            response = varnish_client.request(
+                method="PURGE",
+                url=url,
+            )
+            if response.status_code != 200:
+                success = False
+        return success
 
     return inner

--- a/tests/test_purge_multiple_direct.py
+++ b/tests/test_purge_multiple_direct.py
@@ -1,0 +1,149 @@
+# Standard Library
+import subprocess
+from datetime import datetime
+from time import sleep
+
+# pytest
+import pytest
+
+
+def is_cache_hit(headers: dict) -> bool:
+    """Validate if we have a hit in Varnish."""
+    return headers.get("x-cache") == "HIT"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def multicaching(auth_client):
+    # Enable caching
+    url = "/++api++/@registry"
+    auth_client.patch(
+        url,
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        json={
+            "plone.caching.interfaces.ICacheSettings.enabled": True,
+            "plone.cachepurging.interfaces.ICachePurgingSettings.enabled": True,
+            "plone.cachepurging.interfaces.ICachePurgingSettings.cachingProxies": [
+                "http://purger:80"
+            ],
+            "plone.cachepurging.interfaces.ICachePurgingSettings.domains": [],
+            "plone.cachepurging.interfaces.ICachePurgingSettings.virtualHosting": False,
+            "plone.app.caching.interfaces.IPloneCacheSettings.purgedContentTypes": [
+                "File",
+                "Folder",
+                "Image",
+                "News Item",
+                "Document",
+            ],
+            "plone.cachepurging.interfaces.ICachePurgingSettings.domains": [],
+        },
+    )
+    # spawn second varnish container and wait a second for it to start
+    subprocess.run(["docker", "compose", "up", "--scale", "varnish=2", "-d"])
+    sleep(1.0)
+    yield "Enabled"
+    # Disable caching, disable purge
+    auth_client.patch(
+        url,
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        json={
+            "plone.caching.interfaces.ICacheSettings.enabled": False,
+            "plone.cachepurging.interfaces.ICachePurgingSettings.enabled": False,
+        },
+    )
+    # disable second varnish container
+    subprocess.run(["docker", "compose", "up", "--scale", "varnish=0", "-d"])
+    subprocess.run(["docker", "compose", "up", "--scale", "varnish=1", "-d"])
+
+
+def test_manual_purge_works(
+    anon_client, purge_url, varnish_multiple_clients, purge_multiple_varnish_url
+):
+    # Use image
+    url = "/page/logo-260x260.png/@@images/image/icon"
+
+    # Populate cache for both varnishes
+    anon_client.get(url)
+    anon_client.get(url)
+    # Check url is in cache
+    for varnish in varnish_multiple_clients:
+        headers = varnish.get(url).headers
+        assert is_cache_hit(headers) is True
+
+    # Purge URL
+    assert purge_multiple_varnish_url(url) is True
+    sleep(3.0)
+
+    for varnish in varnish_multiple_clients:
+        headers = varnish.get(url).headers
+        assert is_cache_hit(headers) is False
+
+
+def test_auto_purge_document(
+    anon_client, auth_client, purge_multiple_varnish_url, varnish_multiple_clients
+):
+    prefixes = ("", "/++api++")
+    # Document
+    base_url = "/page"
+
+    for prefix in prefixes:
+        url = f"{prefix}{base_url}"
+        # First cleanup
+        purge_multiple_varnish_url(url)
+        # Populate cache with Volto rendered page and restapi cache
+        anon_client.get(url)
+        anon_client.get(url)
+
+        # Check url is in cache
+        for i in range(5):
+            headers = anon_client.get(url).headers
+            assert is_cache_hit(headers) is True
+
+    # Edit page, should trigger purges
+    now = datetime.utcnow()
+    response = auth_client.patch(
+        f"/++api++{base_url}",
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        json={"title": f"New Page Document {now}"},
+    )
+    assert response.status_code == 204
+    sleep(2.0)
+
+    # To make sure content has been purged in every varnish instance we have to check varnish directly
+    for varnish_client in varnish_multiple_clients:
+        url = base_url
+        headers = varnish_client.get(url).headers
+        assert is_cache_hit(headers) is False
+        url = f"/++api++{base_url}"
+        headers = varnish_client.get(url).headers
+        assert is_cache_hit(headers) is False
+
+
+def test_auto_purge_image(
+    anon_client, auth_client, purge_multiple_varnish_url, varnish_multiple_clients
+):
+    # Use image
+    base_url = "/page/logo-260x260.png"
+    url = f"{base_url}/@@images/image/icon"
+    # Cleanup cache
+    purge_multiple_varnish_url(url)
+    sleep(2.0)
+    # Populate cache
+    anon_client.get(url)
+    anon_client.get(url)
+    # Check url is in cache
+    for client in varnish_multiple_clients:
+        headers = client.get(url).headers
+        assert is_cache_hit(headers) is True
+    # Purge URL
+    now = datetime.utcnow()
+    response = auth_client.patch(
+        f"/++api++/{base_url}",
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        json={"title": f"New Page Document {now}"},
+    )
+    assert response.status_code == 204
+    # Sleep a bit longer to allow purger to propagate
+    sleep(3.0)
+
+    headers = anon_client.get(url).headers
+    assert is_cache_hit(headers) is False

--- a/tests/test_purge_multiple_indirect.py
+++ b/tests/test_purge_multiple_indirect.py
@@ -1,0 +1,151 @@
+# Standard Library
+import subprocess
+from datetime import datetime
+from time import sleep
+
+# HTTP Library
+import httpx
+
+# pytest
+import pytest
+
+
+def is_cache_hit(headers: dict) -> bool:
+    """Validate if we have a hit in Varnish."""
+    return headers.get("x-cache") == "HIT"
+
+
+# Since we do not have direct access to all varnish containers we have to infer
+# via multiple requests and parsing headers wether a url is cached on both varnish
+# containers
+# Varnish sets the Header x-hits as a counter how often this cached content has been 
+# accessed. On the first call to a content that has not been cached it is 0.
+# Every call to this (now cached) document will increase the counter by one.
+# If the x-hits counter did not increase by one on two successive calls to a content
+# we can be sure that those two calls did not go to the same varnish cache
+def check_url_against_multiple_varnish(url: str, client: httpx.Client) -> list:
+    hits = []
+    # First request
+    headers = client.get(url).headers
+    hits.append(headers.get("x-cache") == "HIT")
+    first_request_hits = int(headers.get("x-hits"))
+    # Second request
+    second_request_hits = first_request_hits + 1
+    while second_request_hits == first_request_hits + 1:
+        headers = client.get(url).headers
+        second_request_hits = int(headers.get("x-hits"))
+    hits.append(headers.get("x-cache") == "HIT")
+
+    return hits
+
+
+@pytest.fixture(scope="module", autouse=True)
+def caching(auth_client):
+    # Enable caching
+    url = "/++api++/@registry"
+    auth_client.patch(
+        url,
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        json={
+            "plone.caching.interfaces.ICacheSettings.enabled": True,
+            "plone.cachepurging.interfaces.ICachePurgingSettings.enabled": True,
+            "plone.cachepurging.interfaces.ICachePurgingSettings.cachingProxies": [
+                "http://purger:80"
+            ],
+            "plone.cachepurging.interfaces.ICachePurgingSettings.domains": [],
+            "plone.cachepurging.interfaces.ICachePurgingSettings.virtualHosting": False,
+            "plone.app.caching.interfaces.IPloneCacheSettings.purgedContentTypes": [
+                "File",
+                "Folder",
+                "Image",
+                "News Item",
+                "Document",
+            ],
+            "plone.cachepurging.interfaces.ICachePurgingSettings.domains": [],
+        },
+    )
+    # spawn second varnish container and wait a second for it to start
+    subprocess.run(["docker", "compose", "up", "--scale", "varnish=2", "-d"])
+    sleep(1.0)
+    yield "Enabled"
+    # Disable caching, disable purge
+    auth_client.patch(
+        url,
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        json={
+            "plone.caching.interfaces.ICacheSettings.enabled": False,
+            "plone.cachepurging.interfaces.ICachePurgingSettings.enabled": False,
+        },
+    )
+    # disable second varnish container
+    subprocess.run(["docker", "compose", "up", "--scale", "varnish=0", "-d"])
+    subprocess.run(["docker", "compose", "up", "--scale", "varnish=1", "-d"])
+    sleep(5.0)
+
+
+def test_auto_purge_document(anon_client, auth_client, purge_url):
+    prefixes = ("", "/++api++")
+    # Document
+    base_url = "/page"
+
+    for prefix in prefixes:
+        url = f"{prefix}{base_url}"
+        # First cleanup
+        purge_url(url)
+        purge_url(url)
+        sleep(2.0)
+        # Populate cache with Volto rendered page and restapi cache
+        anon_client.get(url)
+        anon_client.get(url)
+
+        # Check url is in cache
+        for hit in check_url_against_multiple_varnish(url, anon_client):
+            assert hit is True
+
+    # Edit page, should trigger purges
+    now = datetime.utcnow()
+    response = auth_client.patch(
+        f"/++api++{base_url}",
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        json={"title": f"New Page Document {now}"},
+    )
+    assert response.status_code == 204
+    sleep(1.0)
+
+    # Volto should be purged
+    url = base_url
+    for hit in check_url_against_multiple_varnish(url, anon_client):
+        assert hit is False
+
+    # RestAPI should be purged
+    url = f"/++api++{base_url}"
+    for hit in check_url_against_multiple_varnish(url, anon_client):
+        assert hit is False
+
+
+def test_auto_purge_image(anon_client, auth_client, purge_url):
+    # Use image
+    base_url = "/page/logo-260x260.png"
+    url = f"{base_url}/@@images/image/icon"
+    # Cleanup cache
+    purge_url(url)
+    # Populate cache
+    anon_client.get(url)
+    anon_client.get(url)
+    # Check url is in cache
+
+    for hit in check_url_against_multiple_varnish(url, anon_client):
+        assert hit is True
+    # Purge URL
+
+    now = datetime.utcnow()
+    response = auth_client.patch(
+        f"/++api++/{base_url}",
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        json={"title": f"New Page Document {now}"},
+    )
+    assert response.status_code == 204
+    # Sleep a bit longer to allow purger to propagate
+    sleep(3.0)
+    for hit in check_url_against_multiple_varnish(url, anon_client):
+        assert hit is False


### PR DESCRIPTION
@ericof I've added the tests for purging on multiple varnish containers. There are two options for that:

1) [test_purge_multiple_direct.py](https://github.com/collective/volto-caching/compare/testing-multiple-varnish?expand=1#diff-36d42752c040698ecf75a97146476be93ac4bc2fe0f429c37a14f3b0b5b6cc76) -> This only works if the varnish ports are forwarded to the host. In that case we can call the cached URL directly on all varnish containers without going through traefik.

2) [tests/test_purge_multiple_indirect.py](https://github.com/collective/volto-caching/compare/testing-multiple-varnish?expand=1#diff-8f785d9e6d219d0b3e3541970a4df9dbe488579598c3e899c1f0d4f0c5e8fae5) -> Indirect testing by calling the cached content multiple times via traefik and "guessing" from the varnish headers wether the calls went to different varnish containers (Details are described in https://github.com/collective/volto-caching/blob/e0fcc262913a4939f3671553ec8b6f9b6bf70fa6/tests/test_purge_multiple_indirect.py#L18)